### PR TITLE
Disable emote filter (for now)

### DIFF
--- a/filter.json
+++ b/filter.json
@@ -1,7 +1,7 @@
 {
     "queueSize": 6,
     "threshold": 3,
-    "emoteFrequency": 0.5,
+    "emoteFrequency": 1.5,
     "profanity": [
     "fck", "uck", "ngg", "cnt", "unt", "cnt", "bich", "blwjob", "btch", "dck",
     "pssy", "ashole", "ahole", "cck", "sht", "stu", "gto", "godamn", "whre",

--- a/filter.json
+++ b/filter.json
@@ -1,7 +1,6 @@
 {
     "queueSize": 6,
     "threshold": 3,
-    "emoteFrequency": 1.5,
     "profanity": [
     "fck", "uck", "ngg", "cnt", "unt", "cnt", "bich", "blwjob", "btch", "dck",
     "pssy", "ashole", "ahole", "cck", "sht", "stu", "gto", "godamn", "whre",

--- a/modules/filter/Filter.js
+++ b/modules/filter/Filter.js
@@ -1,30 +1,21 @@
 const SizedQueue = require("./SizedQueue");
 const Homoglyphs = require("./Homoglyphs");
 const { Colors } = require("../../constants");
-const onlyEmoji = require('emoji-aware').onlyEmoji;
 
 // Strip unwanted characters that could be used for evading the filter
 const removeSymbols = str =>
     str.replace(/[~\!@#$%^&*()-=_+\[\]{}|"";:\/?.>,<`]/g, "");
-
-// Replace server emotes with regular emojis so that `onlyEmoji` picks them up
-const replaceServerEmotes = str => str.replace(/<:\w+:\d+>/g, "\uD83D\uDC3E");
-
-// Calculate what percentage of chars are emojis.
-// Returns a value between 0 and 1, 0 being no emojis and 1 being completely emojis
-const calculateEmojiFrequency = str => onlyEmoji(str).length / [...str].length;
 
 const filterIcon = "https://cdn.discordapp.com/attachments/306119383820795904/480069533676208130/emoji.png";
 
 class Filter {
     constructor(rawGlyphs, options) {
         this.homoglyphs = Homoglyphs.load(rawGlyphs);
-        this.profanity = options.profanity;
+        this.profanity = options.profanity.map(word => word.toLowerCase().trim());
         this.chain = {
             inner: new SizedQueue(options.queueSize || 0),
             threshold: options.threshold,
         };
-        this.emoteFrequency = options.emoteFrequency || 0.0;
     }
 
     // Checks if the a cleaned message is "good" (meaning that it should not get filtered)
@@ -32,13 +23,12 @@ class Filter {
         const cleanedWords = cleanMessage.split(/\s+/);
 
         return cleanedWords.every(word => !this.profanity.includes(word.toLowerCase())) &&
-            this.chain.inner.countInstances(cleanMessage) < this.chain.threshold &&
-            calculateEmojiFrequency(cleanMessage) < this.emoteFrequency;
+            this.chain.inner.countInstances(cleanMessage) < this.chain.threshold;
     }
 
     // Strips symbols and homoglyphs from a message
     cleanMessage(msg) {
-        return removeSymbols(this.homoglyphs.replace(replaceServerEmotes(msg)));
+        return removeSymbols(this.homoglyphs.replace(msg));
     }
 
     // The main filter method.  Returns a promise

--- a/package-lock.json
+++ b/package-lock.json
@@ -176,15 +176,6 @@
                 "safer-buffer": "2.1.2"
             }
         },
-        "emoji-aware": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/emoji-aware/-/emoji-aware-3.0.4.tgz",
-            "integrity": "sha512-B3VfpErkDYqeN9EdmnMnup73OHO/VpIrhGmMo+eNryeoYkZwBoM4BWDhotbV4cVCNBqEoECQEFJRF9AQZQ1rrA==",
-            "requires": {
-                "lodash.flattendeep": "4.4.0",
-                "parsimmon": "1.12.0"
-            }
-        },
         "es-abstract": {
             "version": "1.12.0",
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
@@ -405,11 +396,6 @@
                 "verror": "1.10.0"
             }
         },
-        "lodash.flattendeep": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-            "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
-        },
         "long": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
@@ -473,11 +459,6 @@
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
             "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc="
-        },
-        "parsimmon": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.12.0.tgz",
-            "integrity": "sha512-uC/BjuSfb4jfaWajKCp1mVncXXq+V1twbcYChbTxN3GM7fn+8XoHwUdvUz+PTaFtDSCRQxU8+Rnh+iMhAkVwdw=="
         },
         "path-is-absolute": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "dependencies": {
         "discord.js": "^11.4.2",
         "dotenv": "^6.0.0",
-        "emoji-aware": "^3.0.4",
         "pg": "^7.4.3",
         "request": "^2.87.0"
     },


### PR DESCRIPTION
Eventually, it would be nice if we could come up with a better filter system.  But as of right now, the backlash is causing more spam than emojis.  Sorry about that.